### PR TITLE
Modified UBReader to read optimized arrays of type uint8 as UBInt8Arrays

### DIFF
--- a/ubjson/src/main/java/com/devsmart/ubjson/UBArray.java
+++ b/ubjson/src/main/java/com/devsmart/ubjson/UBArray.java
@@ -8,6 +8,7 @@ public class UBArray extends UBValue {
     public enum ArrayType {
         Generic,
         Int8,
+        UInt8,
         Int16,
         Int32,
         Int64,

--- a/ubjson/src/main/java/com/devsmart/ubjson/UBInt8Array.java
+++ b/ubjson/src/main/java/com/devsmart/ubjson/UBInt8Array.java
@@ -6,9 +6,13 @@ import java.util.Arrays;
 public final class UBInt8Array extends UBArray {
     private static final long serialVersionUID = 1503819741239478254L;
     private final byte[] mArray;
+    private final boolean unsigned;
+    private final ArrayType type;
 
-    UBInt8Array(byte[] values) {
+    UBInt8Array(byte[] values, boolean unsigned) {
         mArray = values;
+        this.unsigned = unsigned;
+        this.type = unsigned ? ArrayType.UInt8 : ArrayType.Int8;
     }
 
     @Override
@@ -22,7 +26,7 @@ public final class UBInt8Array extends UBArray {
     }
 
     public ArrayType getStrongType() {
-        return ArrayType.Int8;
+        return type;
     }
 
     @Override
@@ -32,7 +36,7 @@ public final class UBInt8Array extends UBArray {
 
     @Override
     public UBValue get(int index) {
-        return UBValueFactory.createInt(mArray[index]);
+        return unsigned ? UBValueFactory.createInt(mArray[index] & 0xFF) : UBValueFactory.createInt(mArray[index]);
     }
 
     public byte[] getValues() {

--- a/ubjson/src/main/java/com/devsmart/ubjson/UBReader.java
+++ b/ubjson/src/main/java/com/devsmart/ubjson/UBReader.java
@@ -230,6 +230,9 @@ public class UBReader implements Closeable {
                 case UBValue.MARKER_INT8:
                     return UBValueFactory.createArray(readOptimizedArrayInt8(size));
 
+                case UBValue.MARKER_UINT8:
+                    return UBValueFactory.createUnsignedArray(readOptimizedArrayInt8(size));
+
                 case UBValue.MARKER_INT16:
                     return UBValueFactory.createArray(readOptimizedArrayInt16(size));
 

--- a/ubjson/src/main/java/com/devsmart/ubjson/UBValueFactory.java
+++ b/ubjson/src/main/java/com/devsmart/ubjson/UBValueFactory.java
@@ -97,7 +97,11 @@ public class UBValueFactory {
     }
 
     public static UBInt8Array createArray(byte[] value) {
-        return new UBInt8Array(value);
+        return new UBInt8Array(value, false);
+    }
+
+    public static UBInt8Array createUnsignedArray(byte[] value) {
+        return new UBInt8Array(value, true);
     }
 
     public static UBValue createArrayOrNull(byte[] value) {

--- a/ubjson/src/test/java/com/devsmart/ubjson/UBReaderTest.java
+++ b/ubjson/src/test/java/com/devsmart/ubjson/UBReaderTest.java
@@ -192,6 +192,25 @@ public class UBReaderTest {
     }
 
     @Test
+    public void readOptimizedUInt8Array() throws Exception {
+        byte[] data;
+        UBReader reader;
+        UBValue value;
+
+        data = new byte[] {'[', '$', 'U', '#', 'U', (byte)2, (byte)0xff, (byte)0x01 };
+        reader = new UBReader(new ByteArrayInputStream(data));
+        value = reader.read();
+        assertTrue(value.isArray());
+        UBArray array = value.asArray();
+        assertEquals(2, array.size());
+        assertTrue(array.get(0).isNumber());
+        assertEquals(255, array.get(0).asInt());
+        assertTrue(array.get(1).isNumber());
+        assertEquals(1, array.get(1).asInt());
+
+    }
+
+    @Test
     public void readOptimizedArrayString() throws Exception {
         byte[] data;
         UBReader reader;


### PR DESCRIPTION
Modified UBReader to read optimized arrays of type uint8 as UBInt8Array's rather than the generic UBArrays.                                                                                                                                  This way the array's contents are stored as the original byte array and the individual array values aren't converted to UBValue shorts.  I believe this to be more efficient and easier to work with as it allows you to call asByteArray on the UBValue representing the array and work with the bytes directly.  Also, wrapping the byte array in a ByteArrayInputStream already does the unsigned conversion for you and is a neat and logical way of reading the optimized array.  Updated UBInt8Array's get method to do the conversion to unsigned if the UBInt8Array is marked as unsigned.  Added a unit test. 

Parsing slippi replays led me to make this change, see the raw array definition if curious https://github.com/project-slippi/slippi-wiki/blob/master/SPEC.md